### PR TITLE
Removed unnecessary requestCollection code

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -35,6 +35,21 @@ DEPENDENCIES:
   - SwiftLint (~> 0.25.0)
   - Whisper (~> 6.0.2)
 
+SPEC REPOS:
+  https://github.com/CocoaPods/Specs.git:
+    - Alamofire
+    - Moya
+    - R.swift
+    - R.swift.Library
+    - Realm
+    - RealmSwift
+    - Result
+    - RxCocoa
+    - RxRealm
+    - RxSwift
+    - SwiftLint
+    - Whisper
+
 SPEC CHECKSUMS:
   Alamofire: 907e0a98eb68cdb7f9d1f541a563d6ac5dc77b25
   Moya: 2b0531a9fef318e0bc484030c3db1e6f279ccb66
@@ -51,4 +66,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: f7ad1a5484661a3e63c61ff1032a1cc3adab5bc1
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.0

--- a/SwiftBaseProject.xcodeproj/project.pbxproj
+++ b/SwiftBaseProject.xcodeproj/project.pbxproj
@@ -339,7 +339,6 @@
 				97C614262056D7A3001FEE20 /* Frameworks */,
 				97C614272056D7A3001FEE20 /* Resources */,
 				EBC5C797142CB9A6E1CF206C /* [CP] Embed Pods Frameworks */,
-				796A37BA30C2A70A44CD69B8 /* [CP] Copy Pods Resources */,
 				97D8232A2056D9C400800FB1 /* SwiftLint */,
 			);
 			buildRules = (
@@ -359,8 +358,6 @@
 				97C614392056D7A3001FEE20 /* Sources */,
 				97C6143A2056D7A3001FEE20 /* Frameworks */,
 				97C6143B2056D7A3001FEE20 /* Resources */,
-				AA588C022E847D7279C4A009 /* [CP] Embed Pods Frameworks */,
-				492D049600D53259525254D9 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -380,8 +377,6 @@
 				97C614442056D7A4001FEE20 /* Sources */,
 				97C614452056D7A4001FEE20 /* Frameworks */,
 				97C614462056D7A4001FEE20 /* Resources */,
-				0BEEBDEC2058D44AFAB5BBC7 /* [CP] Embed Pods Frameworks */,
-				39AA67F73C0E85B5F0138201 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -486,51 +481,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		0BEEBDEC2058D44AFAB5BBC7 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SwiftBaseProjectUITests/Pods-SwiftBaseProjectUITests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		39AA67F73C0E85B5F0138201 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SwiftBaseProjectUITests/Pods-SwiftBaseProjectUITests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		492D049600D53259525254D9 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SwiftBaseProjectTests/Pods-SwiftBaseProjectTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		61C6AD3CFD4BAD4CBD17111B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -567,21 +517,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		796A37BA30C2A70A44CD69B8 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SwiftBaseProject/Pods-SwiftBaseProject-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		97D8232A2056D9C400800FB1 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -609,21 +544,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$PODS_ROOT/R.swift/rswift\" generate \"$SRCROOT\"";
-		};
-		AA588C022E847D7279C4A009 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SwiftBaseProjectTests/Pods-SwiftBaseProjectTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 		EBC5C797142CB9A6E1CF206C /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/SwiftBaseProject/Core/BaseManager.swift
+++ b/SwiftBaseProject/Core/BaseManager.swift
@@ -85,20 +85,6 @@ open class BaseManager<T>: ServiceManager where T: TargetType {
       .asObservable()
   }
 
-  /**
-   Makes a request to the provided target and tries to decode its response as an array
-   using the provided keyPath and return type and returning it as an Observable.
-   - Parameters:
-   - target: The TargetType used to make the request.
-   - keyPath: The keypath used to decode from JSON (if passed nil, it will try to decode from the root).
-   */
-  open func requestCollection<T>(_ target: ProviderType, at keyPath: String? = nil) -> Observable<[T]> where T: Codable {
-    return provider.rx.request(target)
-      .filterSuccessfulStatusCodes()
-      .map([T].self, atKeyPath: keyPath, using: jsonDecoder)
-      .asObservable()
-  }
-
   /// Helper to use as middleware to pretty print the JSON response.
   private func JSONResponseDataFormatter(_ data: Data) -> Data {
     do {


### PR DESCRIPTION
This feature is not necessary anymore, since swift 4.1, `Array<T>` synthesizes `Encodable` by default if `T` is `Encodable`, so we can use `request<T>` for arrays as well.