### PR TITLE
Added the ability to push a router and the identifiable protocol

### DIFF
--- a/SwiftBaseProject.xcodeproj/project.pbxproj
+++ b/SwiftBaseProject.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		97E7D31E205AAE2E009BA321 /* UserDataAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97E7D31D205AAE2E009BA321 /* UserDataAccess.swift */; };
 		97EBDECF205AD5C10085A836 /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97EBDECE205AD5C10085A836 /* DashboardViewModel.swift */; };
 		97EBDED4205ADE360085A836 /* BaseDataAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97EBDED3205ADE360085A836 /* BaseDataAccess.swift */; };
+		C425B3F62267BABD000A4BFF /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C425B3F52267BABD000A4BFF /* Identifiable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -105,6 +106,7 @@
 		9C0F561147B7782F09513410 /* Pods-SwiftBaseProjectUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftBaseProjectUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftBaseProjectUITests/Pods-SwiftBaseProjectUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		A2AEC1BFCBECE7611C3C144A /* Pods_SwiftBaseProjectTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftBaseProjectTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9B94875E31222427017C279 /* Pods_SwiftBaseProjectUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftBaseProjectUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C425B3F52267BABD000A4BFF /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
 		CA6DDFA450FE8259397DA81A /* Pods-SwiftBaseProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftBaseProject.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftBaseProject/Pods-SwiftBaseProject.debug.xcconfig"; sourceTree = "<group>"; };
 		F4591A9718CDDFDBFC90B278 /* Pods-SwiftBaseProject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftBaseProject.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftBaseProject/Pods-SwiftBaseProject.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -166,6 +168,7 @@
 				97139D0A20765A0D007B1C65 /* UIView+ConstraintsHelpers.swift */,
 				1A2BE54621CBF7B5007ECE1C /* NSLayoutConstraint+Helpers.swift */,
 				1A6FEAC121CD1317007DD84A /* GestureRecognizerHandler.swift */,
+				C425B3F52267BABD000A4BFF /* Identifiable.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -609,7 +612,7 @@
 			);
 			name = R.Swift;
 			outputPaths = (
-				"$SRCROOT/R.generated.swift",
+				$SRCROOT/R.generated.swift,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -674,6 +677,7 @@
 				97EBDED4205ADE360085A836 /* BaseDataAccess.swift in Sources */,
 				97E5397C20751D2800D95BDA /* DashBoardRoute.swift in Sources */,
 				97E7D31C205AABE9009BA321 /* UserService.swift in Sources */,
+				C425B3F62267BABD000A4BFF /* Identifiable.swift in Sources */,
 				97D8232D2056DC7B00800FB1 /* R.generated.swift in Sources */,
 				97B83C602056EA8D0096B10A /* BaseManager.swift in Sources */,
 				97E7D31A205AAA57009BA321 /* User.swift in Sources */,

--- a/SwiftBaseProject/Core/Routing.swift
+++ b/SwiftBaseProject/Core/Routing.swift
@@ -64,6 +64,16 @@ public protocol Router: class {
   func navigate(to route: Route, with transition: TransitionType, animated: Bool, completion: (() -> Void)?)
 
   /**
+   Navigate from your current screen to a new entire router. Can only push a router as a modal. Afterwards, other controllers can be pushed inside the presented Router.
+
+   - Parameters:
+   - Router: The destination router that you want to navigate to
+   - animated: Animate the transition or not.
+   - completion: Completion handler.
+   */
+  func navigate(to router: Router, animated: Bool, completion: (() -> Void)?)
+
+  /**
    Handles backwards navigation through the stack.
 
    - Parameters:
@@ -110,6 +120,16 @@ public extension Router {
         }
       }
     }
+  }
+
+  func navigate(to router: Router, animated: Bool, completion: (() -> Void)?) {
+    guard let viewController = router.rootViewController else {
+      assert(false, "Router does not have a root view controller")
+      return
+    }
+
+    currentViewController?.present(viewController, animated: animated, completion: completion)
+    currentViewController = viewController
   }
 
   public func popToRoot(animated: Bool = true) {

--- a/SwiftBaseProject/Core/View/Identifiable.swift
+++ b/SwiftBaseProject/Core/View/Identifiable.swift
@@ -1,0 +1,43 @@
+//
+//  Identifier.swift
+//  SwiftBaseProject
+//
+//  Created by Federico Ojeda on 4/17/19.
+//  Copyright © 2019 Mauricio Cousillas. All rights reserved.
+//
+
+import UIKit
+
+/**
+ Protocol that allows an element to be indentified. By default, it uses it's class name as the indentifier. This is particularly useful for UITableViewCell and UICollectionViewCell instances, where a reuseIdentifier is needed.
+
+ Usage:
+ 
+ * `class MyCell: UICollectionViewCell, Identifiable { }`
+
+ Whenever the reuseIdentifier is needed:
+
+  * .. `MyCell.identifier` ..
+ */
+protocol Identifiable {
+  static var identifier: String { get }
+}
+
+extension Identifiable {
+  static var identifier: String {
+    return String(describing: type(of: Self.self))
+  }
+}
+
+extension Identifiable where Self: UITableViewCell {
+  var reuseIdentifier: String? {
+    return Self.identifier
+  }
+}
+
+extension Identifiable where Self: UICollectionViewCell {
+  var reuseIdentifier: String? {
+    return Self.identifier
+  }
+}
+


### PR DESCRIPTION
* Added the ability to push a router instead of only a route. This allows to push a navigation controller when presenting modally. The Router pushed then can have other controllers push inside it.

* Added the identifiable protocol, which allows an element to have an identifier created by its name. This is particularly useful for Cells (UITableView and UICollectionView), where a reuse identifier is needed. Protocol extensions are added for this classes in order to avoid having the reuseIdentifier repeated in several places